### PR TITLE
[proposal] chore: remove branch push trigger

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,8 +2,6 @@ name: Build and Publish to Docker Hub
 
 on:
   push:
-    branches:
-      - master
     tags:
       - 'v*'
 


### PR DESCRIPTION
- tagをつけるときの手順としては下記を想定しています
  1. 修正したコードのmasterへのPRを起票
  2. masterへmerge
  3. tagを付与
  4. image作成
  これは3をtriggerにCIにて実行される
- masterへのpushをimage buildのtriggerにしておくと、同じtagで違うcommit hashのimageが作成されることになります
- これを防ぐため、master branchへのpushのtrigger削除を提案します